### PR TITLE
LokiHandler: Set CURLOPT_RETURNTRANSFER to true

### DIFF
--- a/src/main/php/Handler/LokiHandler.php
+++ b/src/main/php/Handler/LokiHandler.php
@@ -81,7 +81,7 @@ class LokiHandler extends AbstractProcessingHandler
         }
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
         curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, false);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt(
             $ch,
             CURLOPT_HTTPHEADER,


### PR DESCRIPTION
Prevents unwanted output to stdout when the Loki server is not reachable.

Fixes #2