### PR TITLE
Custom curl options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ $handler = new WhatFailureGroupHandler(
                 ],
                 // Optional : Override the default curl options with custom values
                 'curl_options' => [
-                  CURLOPT_CONNECTTIMEOUT_MS => 500,
-                  CURLOPT_TIMEOUT_MS => 600
+                    CURLOPT_CONNECTTIMEOUT_MS => 500,
+                    CURLOPT_TIMEOUT_MS => 600
                 ]
             ]
         )
@@ -45,42 +45,43 @@ $handler = new WhatFailureGroupHandler(
 
 ### Configure LokiHandler Service
 ```yaml
-Itspire\MonologLoki\Handler\LokiHandler:
-  arguments:
-    $apiConfig:
-      entrypoint: "http://loki:3100"
-      context:
-        app: My-app
-      labels:
-        env: "%env(APP_ENV)%"
-      client_name: my_app_server
-      auth:
-        basic:
-          user: username
-          password: password
+  Itspire\MonologLoki\Handler\LokiHandler:
+    arguments:
+      $apiConfig:
+        entrypoint: 'http://loki:3100'
+        context:
+          app: My-app
+        labels:
+          env: '%env(APP_ENV)%'
+        client_name: my_app_server
+        auth:
+          basic:
+            user: username
+            password: password
 ```
-
-Note :
+Note : 
 We're currently working on a possible bundle based implementation for Symfony but at the moment, this is the way.
 
-### Configure Monolog to use Loki Handler
-```yaml
-  monolog:
-    handlers:
-      loki:
-        type: service
-        id: Itspire\MonologLoki\Handler\LokiHandler
 
-      my_loki_handler:
-        type: whatfailuregroup
-        members: [loki]
-        level: debug
-        process_psr_3_messages: true # optional but we find it rather useful (Note : native handler required to use)
+### Configure Monolog to use Loki Handler
+
+```yaml
+monolog:
+  handlers:
+    loki:
+      type: service
+      id: Itspire\MonologLoki\Handler\LokiHandler
+
+    my_loki_handler:
+      type:   whatfailuregroup
+      members: [loki]
+      level: debug
+      process_psr_3_messages: true # optional but we find it rather useful (Note : native handler required to use)
 ```
 
 # Testing
 In order to test using the provided docker-compose file, you'll need an up-to-date docker/docker-compose installation
-You can start the Loki container by navigating to src/main/test/docker and running
+You can start the Loki container by navigating to src/main/test/docker and running 
 ```shell script
 docker-compose up
 ```
@@ -90,31 +91,31 @@ If you're testing from a local php installation, you'll need to retrieve the Lok
 docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' itspire-monolog-loki_loki_1
 ```
 
-If you're testing from containerized php, you'll need to start the container with an extra host named Loki
+If you're testing from containerized php, you'll need to start the container with an extra host named Loki 
 mapped to your current host ip, using the following option :
 ```shell script
 --add-host loki:{your_host_ip}
 ```
 
 Run the test using phpunit and you can verify that posting to Loki works
-by running the following from your host terminal :
+by running the following from your host terminal : 
 ```shell script
 curl -G -s  "http://localhost:3100/loki/api/v1/query" --data-urlencode 'query={channel="test"}' | jq
 ```
 
-For each time you ran the tests, you should see a log entry looking like the following :
+For each time you ran the tests, you should see a log entry looking like the following : 
 ```json
 {
     "stream": {
-      "channel": "test",
-      "host": "f2bbe48b0204",
-      "level_name": "WARNING"
+        "channel": "test",
+        "host": "f2bbe48b0204",
+        "level_name": "WARNING"
     },
     "values": [
-      [
+        [
         "1591627127000000000",
         "{\"message\":\"test\",\"level\":300,\"level_name\":\"WARNING\",\"channel\":\"test\",\"datetime\":\"2020-06-08 14:38:47\",\"ctxt_data\":\"[object] (stdClass: {})\",\"ctxt_foo\":\"34\"}"
-      ]
+        ]
     ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ $handler = new WhatFailureGroupHandler(
           basic:
             user: username
             password: password
+        curl_options:
+          !php/const CURLOPT_CONNECTTIMEOUT_MS: 500,
+          !php/const CURLOPT_TIMEOUT_MS: 600
 ```
 Note : 
 We're currently working on a possible bundle based implementation for Symfony but at the moment, this is the way.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ $handler = new WhatFailureGroupHandler(
 );
 ```
 
+### Non-customizable curl options
+The following options are not customizable in the configuration:
+
+- `CURLOPT_CUSTOMREQUEST`
+- `CURLOPT_RETURNTRANSFER`
+- `CURLOPT_POSTFIELDS`
+- `CURLOPT_HTTPHEADER`
+
 ## Symfony App
 
 ### Configure LokiHandler Service

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Since Loki log handling uses a remote server, logging is prone to be subject of 
 To avoid your application being broken in such a case, we recommend wrapping the handler in a WhatFailureGroupHandler
 
 ## Native
-
 ```php
 use Itspire\MonologLoki\Handler\LokiHandler;
 use Monolog\Handler\WhatFailureGroupHandler;
@@ -45,7 +44,6 @@ $handler = new WhatFailureGroupHandler(
 ## Symfony App
 
 ### Configure LokiHandler Service
-
 ```yaml
 Itspire\MonologLoki\Handler\LokiHandler:
   arguments:
@@ -56,70 +54,67 @@ Itspire\MonologLoki\Handler\LokiHandler:
       labels:
         env: "%env(APP_ENV)%"
       client_name: my_app_server
+      auth:
+        basic:
+          user: username
+          password: password
 ```
 
 Note :
 We're currently working on a possible bundle based implementation for Symfony but at the moment, this is the way.
 
 ### Configure Monolog to use Loki Handler
-
 ```yaml
-monolog:
-  handlers:
-    loki:
-      type: service
-      id: Itspire\MonologLoki\Handler\LokiHandler
+  monolog:
+    handlers:
+      loki:
+        type: service
+        id: Itspire\MonologLoki\Handler\LokiHandler
 
-    my_loki_handler:
-      type: whatfailuregroup
-      members: [loki]
-      level: debug
-      process_psr_3_messages: true # optional but we find it rather useful (Note : native handler required to use)
+      my_loki_handler:
+        type: whatfailuregroup
+        members: [loki]
+        level: debug
+        process_psr_3_messages: true # optional but we find it rather useful (Note : native handler required to use)
 ```
 
 # Testing
-
 In order to test using the provided docker-compose file, you'll need an up-to-date docker/docker-compose installation
 You can start the Loki container by navigating to src/main/test/docker and running
-
 ```shell script
 docker-compose up
 ```
 
 If you're testing from a local php installation, you'll need to retrieve the Loki container ip with :
-
 ```shell script
 docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' itspire-monolog-loki_loki_1
 ```
 
 If you're testing from containerized php, you'll need to start the container with an extra host named Loki
 mapped to your current host ip, using the following option :
-
 ```shell script
 --add-host loki:{your_host_ip}
 ```
 
 Run the test using phpunit and you can verify that posting to Loki works
 by running the following from your host terminal :
-
 ```shell script
 curl -G -s  "http://localhost:3100/loki/api/v1/query" --data-urlencode 'query={channel="test"}' | jq
 ```
 
 For each time you ran the tests, you should see a log entry looking like the following :
-
 ```json
 {
-  "stream": {
-    "channel": "test",
-    "host": "f2bbe48b0204",
-    "level_name": "WARNING"
-  },
-  "values": [
-    [
-      "1591627127000000000",
-      "{\"message\":\"test\",\"level\":300,\"level_name\":\"WARNING\",\"channel\":\"test\",\"datetime\":\"2020-06-08 14:38:47\",\"ctxt_data\":\"[object] (stdClass: {})\",\"ctxt_foo\":\"34\"}"
+    "stream": {
+      "channel": "test",
+      "host": "f2bbe48b0204",
+      "level_name": "WARNING"
+    },
+    "values": [
+      [
+        "1591627127000000000",
+        "{\"message\":\"test\",\"level\":300,\"level_name\":\"WARNING\",\"channel\":\"test\",\"datetime\":\"2020-06-08 14:38:47\",\"ctxt_data\":\"[object] (stdClass: {})\",\"ctxt_foo\":\"34\"}"
+      ]
     ]
-  ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Since Loki log handling uses a remote server, logging is prone to be subject of 
 To avoid your application being broken in such a case, we recommend wrapping the handler in a WhatFailureGroupHandler
 
 ## Native
+
 ```php
 use Itspire\MonologLoki\Handler\LokiHandler;
 use Monolog\Handler\WhatFailureGroupHandler;
@@ -30,6 +31,11 @@ $handler = new WhatFailureGroupHandler(
                 'auth' => [
                     'basic' => ['user', 'password'],
                 ],
+                // Optional : Override the default curl options with custom values
+                'curl_options' => [
+                  CURLOPT_CONNECTTIMEOUT_MS => 500,
+                  CURLOPT_TIMEOUT_MS => 600
+                ]
             ]
         )
     ]
@@ -39,20 +45,21 @@ $handler = new WhatFailureGroupHandler(
 ## Symfony App
 
 ### Configure LokiHandler Service
-```yaml
-  Itspire\MonologLoki\Handler\LokiHandler:
-    arguments:
-      $apiConfig:
-        entrypoint: 'http://loki:3100'
-        context:
-          app: My-app
-        labels:
-          env: '%env(APP_ENV)%'
-        client_name: my_app_server
-```
-Note : 
-We're currently working on a possible bundle based implementation for Symfony but at the moment, this is the way.
 
+```yaml
+Itspire\MonologLoki\Handler\LokiHandler:
+  arguments:
+    $apiConfig:
+      entrypoint: "http://loki:3100"
+      context:
+        app: My-app
+      labels:
+        env: "%env(APP_ENV)%"
+      client_name: my_app_server
+```
+
+Note :
+We're currently working on a possible bundle based implementation for Symfony but at the moment, this is the way.
 
 ### Configure Monolog to use Loki Handler
 
@@ -64,49 +71,55 @@ monolog:
       id: Itspire\MonologLoki\Handler\LokiHandler
 
     my_loki_handler:
-      type:   whatfailuregroup
+      type: whatfailuregroup
       members: [loki]
       level: debug
       process_psr_3_messages: true # optional but we find it rather useful (Note : native handler required to use)
 ```
 
 # Testing
+
 In order to test using the provided docker-compose file, you'll need an up-to-date docker/docker-compose installation
-You can start the Loki container by navigating to src/main/test/docker and running 
+You can start the Loki container by navigating to src/main/test/docker and running
+
 ```shell script
 docker-compose up
 ```
 
 If you're testing from a local php installation, you'll need to retrieve the Loki container ip with :
+
 ```shell script
 docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' itspire-monolog-loki_loki_1
 ```
 
-If you're testing from containerized php, you'll need to start the container with an extra host named Loki 
+If you're testing from containerized php, you'll need to start the container with an extra host named Loki
 mapped to your current host ip, using the following option :
+
 ```shell script
 --add-host loki:{your_host_ip}
 ```
 
 Run the test using phpunit and you can verify that posting to Loki works
-by running the following from your host terminal : 
+by running the following from your host terminal :
+
 ```shell script
 curl -G -s  "http://localhost:3100/loki/api/v1/query" --data-urlencode 'query={channel="test"}' | jq
 ```
 
-For each time you ran the tests, you should see a log entry looking like the following : 
+For each time you ran the tests, you should see a log entry looking like the following :
+
 ```json
 {
-    "stream": {
-        "channel": "test",
-        "host": "f2bbe48b0204",
-        "level_name": "WARNING"
-    },
-    "values": [
-        [
-        "1591627127000000000",
-        "{\"message\":\"test\",\"level\":300,\"level_name\":\"WARNING\",\"channel\":\"test\",\"datetime\":\"2020-06-08 14:38:47\",\"ctxt_data\":\"[object] (stdClass: {})\",\"ctxt_foo\":\"34\"}"
-        ]
+  "stream": {
+    "channel": "test",
+    "host": "f2bbe48b0204",
+    "level_name": "WARNING"
+  },
+  "values": [
+    [
+      "1591627127000000000",
+      "{\"message\":\"test\",\"level\":300,\"level_name\":\"WARNING\",\"channel\":\"test\",\"datetime\":\"2020-06-08 14:38:47\",\"ctxt_data\":\"[object] (stdClass: {})\",\"ctxt_foo\":\"34\"}"
     ]
+  ]
 }
 ```

--- a/src/main/php/Handler/LokiHandler.php
+++ b/src/main/php/Handler/LokiHandler.php
@@ -36,6 +36,14 @@ class LokiHandler extends AbstractProcessingHandler
     /** custom curl options */
     protected array $customCurlOptions = [];
 
+    /** curl options which cannot be customized */
+    protected array $nonCustomizableCurlOptions = [
+        CURLOPT_CUSTOMREQUEST,
+        CURLOPT_RETURNTRANSFER,
+        CURLOPT_POSTFIELDS,
+        CURLOPT_HTTPHEADER,
+    ];
+
     /** @return false|null|resource */
     private $connection;
 
@@ -49,10 +57,19 @@ class LokiHandler extends AbstractProcessingHandler
         $this->globalContext = $apiConfig['context'] ?? [];
         $this->globalLabels = $apiConfig['labels'] ?? [];
         $this->systemName = $apiConfig['client_name'] ?? null;
-        $this->customCurlOptions = $apiConfig['curl_options'] ?? [];
+        $this->customCurlOptions = $this->determineValidCustomCurlOptions($apiConfig['curl_options'] ?? []);
         if (isset($apiConfig['auth']['basic'])) {
             $this->basicAuth = (2 === count($apiConfig['auth']['basic'])) ? $apiConfig['auth']['basic'] : [];
         }
+    }
+
+    private function determineValidCustomCurlOptions(array $configuredCurlOptions): array
+    {
+        foreach ($this->nonCustomizableCurlOptions as $option) {
+            unset($configuredCurlOptions[$option]);
+        }
+
+        return $configuredCurlOptions;
     }
 
     private function getEntrypoint(string $entrypoint): string

--- a/src/main/php/Handler/LokiHandler.php
+++ b/src/main/php/Handler/LokiHandler.php
@@ -94,17 +94,20 @@ class LokiHandler extends AbstractProcessingHandler
         }
 
         if (false !== $this->connection) {
-            $curlOptions = array_replace([
-                CURLOPT_CONNECTTIMEOUT_MS => 100,
-                CURLOPT_TIMEOUT_MS => 200,
-                CURLOPT_CUSTOMREQUEST => 'POST',
-                CURLOPT_RETURNTRANSFER => true,
-                CURLOPT_POSTFIELDS => $payload,
-                CURLOPT_HTTPHEADER => [
-                    'Content-Type: application/json',
-                    'Content-Length: ' . strlen($payload),
+            $curlOptions = array_replace(
+                [
+                    CURLOPT_CONNECTTIMEOUT_MS => 100,
+                    CURLOPT_TIMEOUT_MS => 200,
+                    CURLOPT_CUSTOMREQUEST => 'POST',
+                    CURLOPT_RETURNTRANSFER => true,
+                    CURLOPT_POSTFIELDS => $payload,
+                    CURLOPT_HTTPHEADER => [
+                        'Content-Type: application/json',
+                        'Content-Length: ' . strlen($payload),
+                    ],
                 ],
-            ], $this->customCurlOptions);
+                $this->customCurlOptions
+            );
 
             if (!empty($this->basicAuth)) {
                 $curlOptions[CURLOPT_HTTPAUTH] = CURLAUTH_BASIC;

--- a/src/main/php/Handler/LokiHandler.php
+++ b/src/main/php/Handler/LokiHandler.php
@@ -33,6 +33,9 @@ class LokiHandler extends AbstractProcessingHandler
     /** the list of default labels to be sent to the Loki system */
     protected array $globalLabels = [];
 
+    /** custom curl options */
+    protected array $customCurlOptions = [];
+
     /** @return false|null|resource */
     private $connection;
 
@@ -46,6 +49,7 @@ class LokiHandler extends AbstractProcessingHandler
         $this->globalContext = $apiConfig['context'] ?? [];
         $this->globalLabels = $apiConfig['labels'] ?? [];
         $this->systemName = $apiConfig['client_name'] ?? null;
+        $this->customCurlOptions = $apiConfig['curl_options'] ?? [];
         if (isset($apiConfig['auth']['basic'])) {
             $this->basicAuth = (2 === count($apiConfig['auth']['basic'])) ? $apiConfig['auth']['basic'] : [];
         }
@@ -90,7 +94,7 @@ class LokiHandler extends AbstractProcessingHandler
         }
 
         if (false !== $this->connection) {
-            $curlOptions = [
+            $curlOptions = array_merge([
                 CURLOPT_CONNECTTIMEOUT_MS => 100,
                 CURLOPT_TIMEOUT_MS => 200,
                 CURLOPT_CUSTOMREQUEST => 'POST',
@@ -100,7 +104,7 @@ class LokiHandler extends AbstractProcessingHandler
                     'Content-Type: application/json',
                     'Content-Length: ' . strlen($payload),
                 ],
-            ];
+            ], $this->customCurlOptions);
 
             if (!empty($this->basicAuth)) {
                 $curlOptions[CURLOPT_HTTPAUTH] = CURLAUTH_BASIC;

--- a/src/main/php/Handler/LokiHandler.php
+++ b/src/main/php/Handler/LokiHandler.php
@@ -94,7 +94,7 @@ class LokiHandler extends AbstractProcessingHandler
         }
 
         if (false !== $this->connection) {
-            $curlOptions = $this->customCurlOptions + [
+            $curlOptions = array_replace([
                 CURLOPT_CONNECTTIMEOUT_MS => 100,
                 CURLOPT_TIMEOUT_MS => 200,
                 CURLOPT_CUSTOMREQUEST => 'POST',
@@ -104,7 +104,7 @@ class LokiHandler extends AbstractProcessingHandler
                     'Content-Type: application/json',
                     'Content-Length: ' . strlen($payload),
                 ],
-            ];
+            ], $this->customCurlOptions);
 
             if (!empty($this->basicAuth)) {
                 $curlOptions[CURLOPT_HTTPAUTH] = CURLAUTH_BASIC;

--- a/src/main/php/Handler/LokiHandler.php
+++ b/src/main/php/Handler/LokiHandler.php
@@ -94,7 +94,7 @@ class LokiHandler extends AbstractProcessingHandler
         }
 
         if (false !== $this->connection) {
-            $curlOptions = array_merge([
+            $curlOptions = $this->customCurlOptions + [
                 CURLOPT_CONNECTTIMEOUT_MS => 100,
                 CURLOPT_TIMEOUT_MS => 200,
                 CURLOPT_CUSTOMREQUEST => 'POST',
@@ -104,7 +104,7 @@ class LokiHandler extends AbstractProcessingHandler
                     'Content-Type: application/json',
                     'Content-Length: ' . strlen($payload),
                 ],
-            ], $this->customCurlOptions);
+            ];
 
             if (!empty($this->basicAuth)) {
                 $curlOptions[CURLOPT_HTTPAUTH] = CURLAUTH_BASIC;


### PR DESCRIPTION
When logging to a remote system, the configured CURL timeout of 100ms is sometimes too short and log messages get partially or totally lost.

Seeing how you've changed the timeout multiple times I propose a simple solution to make the curl options overridable by setting an optional array key on the api configuration array.