### PR TITLE
We need to update Monolog to work with Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require": {
     "php": ">=7.4",
-    "monolog/monolog": "^1.25"
+    "monolog/monolog": "~1.25|~2.0"
   },
   "require-dev": {
     "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require": {
     "php": ">=7.4",
-    "monolog/monolog": "^2.0"
+    "monolog/monolog": "^1.25"
   },
   "require-dev": {
     "ext-json": "*",


### PR DESCRIPTION
I tried to use the library as it, but not possible because Laravel 8 uses Monolog 2.2 or higher. The point is that I tested it with Monolog ^2.0 and works like a charm. It is possible to work with Laravel logging system. 

May be the change is better if ^1.25 to work on old and new systems?