### PR TITLE
Add config to turn off sending the logs to Loki

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ $handler = new WhatFailureGroupHandler(
                     // Set here your globally applicable labels
                 ],
                 'client_name' => 'your_host_name', // Here set a unique identifier for the client host
+                'is_sending_enabled' => true, // Whether the handler will actually send the logs to Loki (this option is useful for turning the sending off while running tests in CI so that it does not slow down tests)
                 // Optional : if you're using basic auth to authentify
                 'auth' => [
                     'basic' => ['user', 'password'],
@@ -62,6 +63,7 @@ The following options are not customizable in the configuration:
         labels:
           env: '%env(APP_ENV)%'
         client_name: my_app_server
+        is_sending_enabled: '%env(bool:IS_LOKI_LOGGING_ENABLED)%'
         auth:
           basic:
             user: username
@@ -111,6 +113,7 @@ monolog:
             'context'     => [],
             'labels'      => [],
             'client_name' => '',
+            'is_sending_enabled' => (bool) env('IS_LOKI_LOGGING_ENABLED', true),
             'auth' => [
                 'basic' => [
                     env('LOKI_AUTH_BASIC_USER', ''), 
@@ -179,6 +182,7 @@ Update the config accordingly:
             'context'     => [],
             'labels'      => [],
             'client_name' => '',
+            'is_sending_enabled' => (bool) env('IS_LOKI_LOGGING_ENABLED', true),
             'auth' => [
                 'basic' => [
                     env('LOKI_AUTH_BASIC_USER', ''),

--- a/src/test/php/Handler/LokiHandlerTest.php
+++ b/src/test/php/Handler/LokiHandlerTest.php
@@ -26,6 +26,7 @@ class LokiHandlerTest extends TestCase
                 'context' => [],
                 'labels' => [],
                 'client_name' => 'test',
+                'is_sending_enabled' => true,
                 'auth' => [
                     'basic' => ['user', 'password'],
                 ],
@@ -33,12 +34,33 @@ class LokiHandlerTest extends TestCase
         );
 
         static::assertInstanceOf(LokiHandler::class, $handler);
+        static::assertTrue($handler->isHandling($record));
 
         try {
             $handler->handle($record);
         } catch (\RuntimeException $e) {
             static::markTestSkipped('Could not connect to Loki server on ' . getenv('LOKI_ENTRYPOINT'));
         }
+    }
+
+    public function testIsHandlingReturnsFalseWhenSendingIsDisabled(): void
+    {
+        $record = $this->getRecord(Logger::WARNING, 'test', ['data' => new \stdClass(), 'foo' => 34]);
+
+        $handler = new LokiHandler(
+            [
+                'entrypoint' => getenv('LOKI_ENTRYPOINT'),
+                'context' => [],
+                'labels' => [],
+                'client_name' => 'test',
+                'is_sending_enabled' => false,
+                'auth' => [
+                    'basic' => ['user', 'password'],
+                ],
+            ]
+        );
+
+        static::assertFalse($handler->isHandling($record));
     }
 
     protected function getRecord($level = Logger::WARNING, $message = 'test', array $context = []): array


### PR DESCRIPTION
After configuring the logger in our Laravel app I've noticed that the test runs in the CI pipeline became a lot slower. Turns out that the package is always trying to ping Loki and since our Docker CI setup has no internet connectivity (on purpose) that slows down the tests as the handler waits until curl timeouts.

I've added a new config setting to address that so that we can disable this handler for the test environment.