### PR TITLE
Microsecond precision for timestamp

### DIFF
--- a/src/main/php/Formatter/LokiFormatter.php
+++ b/src/main/php/Formatter/LokiFormatter.php
@@ -56,7 +56,8 @@ class LokiFormatter extends NormalizerFormatter
             'stream' => array_merge($this->labels, $customLabels, $this->getMonologLabels($preparedRecord)),
             'values' => [
                 [
-                    (string) ($record->datetime->getTimestamp() * 1000000000),
+                    // use format() instead of getTimestamp() to get microsecond precision
+                    $record->datetime->format("Uu")."000",
                     $this->toJson($this->normalize($preparedRecord)),
                 ],
             ],


### PR DESCRIPTION
Current implementation only has second precision, in case of fast back-to-back logging log order can be scrambled.
This PR implements microsecond precision to avoid this situation when microsecond logging is enabled.